### PR TITLE
use sha256 and avoid deprecation warnings

### DIFF
--- a/contacts2.rb
+++ b/contacts2.rb
@@ -6,7 +6,7 @@ require 'formula'
 class Contacts2 < Formula
   homepage 'https://github.com/tgray/contacts'
   url 'https://github.com/tgray/contacts/archive/0.2.tar.gz'
-  sha1 '8a74376012925159363fb76e01110cacda9b42f4'
+  sha256 '38ce504dc66473f75767c3cae7228f0bfc06c9e2f8b96ed4f9cd99f73a7969d3'
 
   conflicts_with 'contacts', :because => 'contacts is no longer maintained and this formula replaces it.'
 

--- a/muttqt.rb
+++ b/muttqt.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Muttqt < Formula
   homepage 'https://github.com/tgray/muttqt'
   url 'https://github.com/tgray/muttqt/archive/0.1.0.tar.gz'
-  sha1 '6df69a2e0c3548655e682eee7c848e7271e02b5f'
+  sha256 '2bdd888fa6fb95e0f96e08090595c8c94e0913e9db672aa863cb2da576794fda'
   version '0.1.0'
 
   def install


### PR DESCRIPTION
updates `muttqt` and `contacts2` recipes to use sha256 hashes
